### PR TITLE
Use --fasttext-model in apy.service

### DIFF
--- a/tools/apertium-apy/debian/apertium-apy.service
+++ b/tools/apertium-apy/debian/apertium-apy.service
@@ -7,7 +7,7 @@ After=network.target
 # Change this to your username and edit to how you start apy:
 User=apertium
 WorkingDirectory=/usr/share/apertium-apy/tools
-ExecStart=/usr/bin/apertium-apy /usr/share/apertium/modes
+ExecStart=/usr/bin/python3 servlet.py --fasttext-model /usr/share/apertium-apy/lid.release.ftz /usr/share/apertium/modes
 Environment=LC_ALL=C.UTF-8
 
 # By default, if it restarts >10 times within 5 secs, it marks it as failed and gives up:

--- a/tools/apertium-apy/debian/control
+++ b/tools/apertium-apy/debian/control
@@ -35,6 +35,7 @@ Depends: adduser,
 Recommends: python3-chardet,
             python3-lxml,
             python3-requests,
+            python3-fasttext,
             python3-streamparser
 Description: Apertium APY service
  This package contains Apertium APY which is simple Apertium


### PR DESCRIPTION
and add the dependency to Recommends (the service will still start without it, even with that option)